### PR TITLE
Implement generic webhook endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 ## Introduction
 
-TODO Describe what your plugin does here
+Generic Webhook is a simple Jenkins plugin that exposes a public endpoint to
+trigger pipelines from external systems. Requests are sent to
+`/generic-webhook/{pipelineName}` using the `POST` method with any JSON body.
+The JSON payload is forwarded to the triggered pipeline as a parameter named
+`webhookPayload`.
 
 ## Getting started
 
-TODO Tell users how to configure your plugin here, include screenshots, pipeline examples and 
-configuration-as-code examples.
+Configure your pipeline to declare a string parameter called `webhookPayload`.
+Then send a `POST` request to `/generic-webhook/<job name>` with your JSON
+payload. Inside the pipeline access it via `params.webhookPayload`.
 
 ## Issues
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,4 +64,15 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+  </dependencies>
 </project>

--- a/src/main/java/io/jenkins/plugins/genericwebhook/GenericWebhookEndpoint.java
+++ b/src/main/java/io/jenkins/plugins/genericwebhook/GenericWebhookEndpoint.java
@@ -1,0 +1,98 @@
+package io.jenkins.plugins.genericwebhook;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hudson.model.Action;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.ParametersAction;
+import hudson.model.StringParameterValue;
+import hudson.model.QueueTaskFuture;
+import hudson.model.Run;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import hudson.Extension;
+import jenkins.model.UnprotectedRootAction;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Exposes a generic webhook endpoint to trigger pipelines.
+ */
+@Extension
+public class GenericWebhookEndpoint implements UnprotectedRootAction {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public String getUrlName() {
+        return "generic-webhook";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Generic Webhook";
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null; // hidden from side-panel
+    }
+
+    /**
+     * Handles POST requests to /generic-webhook/{pipelineName}.
+     */
+    public void doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException {
+        if (!"POST".equalsIgnoreCase(req.getMethod())) {
+            rsp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Only POST supported");
+            return;
+        }
+
+        String rest = req.getRestOfPath();
+        if (rest == null || rest.isEmpty() || rest.equals("/")) {
+            rsp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Pipeline name required");
+            return;
+        }
+        if (rest.startsWith("/")) {
+            rest = rest.substring(1);
+        }
+        String pipelineName = rest;
+
+        String body = req.getReader().lines()
+                .reduce("", (a, b) -> a + b);
+
+        try {
+            MAPPER.readTree(body);
+        } catch (IOException ex) {
+            rsp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid JSON body");
+            return;
+        }
+
+        WorkflowJob job = Jenkins.get().getItemByFullName(pipelineName, WorkflowJob.class);
+        if (job == null) {
+            rsp.sendError(HttpServletResponse.SC_NOT_FOUND, "Pipeline not found: " + pipelineName);
+            return;
+        }
+        if (!job.isBuildable()) {
+            rsp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Pipeline not buildable: " + pipelineName);
+            return;
+        }
+
+        List<Action> actions = new ArrayList<>();
+        actions.add(new ParametersAction(new StringParameterValue("webhookPayload", body)));
+        actions.add(new CauseAction(new Cause.RemoteCause(req.getRemoteAddr(), "Triggered via generic webhook")));
+
+        QueueTaskFuture<? extends Run<?, ?>> future = job.scheduleBuild2(0, actions.toArray(new Action[0]));
+        if (future == null) {
+            rsp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Failed to schedule build");
+            return;
+        }
+
+        rsp.setStatus(HttpServletResponse.SC_ACCEPTED);
+        rsp.getWriter().println("Triggered pipeline " + pipelineName);
+    }
+}

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-    TODO
+    The Generic Webhook endpoint is available at <code>/generic-webhook/&lt;pipelineName&gt;</code>.
 </div>


### PR DESCRIPTION
## Summary
- add new `GenericWebhookEndpoint` that listens on `/generic-webhook/{pipeline}`
- pass JSON payload to job as `webhookPayload`
- update pom dependencies
- document usage in README
- add simple index page message

## Testing
- ❌ `mvn -q -DskipTests clean package` *(failed: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68744dbabfe883228181e815100cf036